### PR TITLE
Update nan dependency to v1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "url": "http://elevengiants.com"
   },
   "dependencies": {
-    "nan": "^1.6.2"
+    "nan": "^1.8.0"
   }
 }


### PR DESCRIPTION
nan >= 1.8 is required for compatibility with V8 4.2 (which ships with io.js >= 2).
I tried running the tests (`tests/should.js`), which reported a couple of errors, and ended with "70/80 tests passing.". Not sure if those indicate actual problems/incompatibilities with the new V8 version – are all tests currently expected to pass?